### PR TITLE
Add --lf to replace CRLF with LF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: csharp
+solution: pasteboard.sln
+
+before_deploy:
+  - rm -rf dist && mkdir dist && cp pbcopy/bin/Release/pbcopy.exe pbpaste/bin/Release/pbpaste.exe dist
+  - (cd dist && zip -r pasteboard-$TRAVIS_TAG-windows.zip . && sha256sum pasteboard-$TRAVIS_TAG-windows.zip | cut -d ' ' -f 1 >pasteboard-$TRAVIS_TAG-windows.zip.sha256)
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  name: $TRAVIS_TAG
+  file:
+    - dist/pasteboard-$TRAVIS_TAG-windows.zip
+    - dist/pasteboard-$TRAVIS_TAG-windows.zip.sha256
+  skip_cleanup: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+# Pasteboard
+
+[![Build Status](https://travis-ci.org/uzxmx/pasteboard.svg?branch=master)](https://travis-ci.org/uzxmx/pasteboard)
 ![Icon](https://i.imgur.com/rVJVL3U.png)
-## Pasteboard
 
 Your favourite OSX command line clipboard manipulation libraries `pbcopy` and `pbpaste`ported over to Windows.
 
@@ -8,23 +10,46 @@ Your favourite OSX command line clipboard manipulation libraries `pbcopy` and `p
 
 ## Installation
 
-Installation is done via [Chocolatey](https://chocolatey.org/packages/pasteboard):
+Installation is done via [scoop](https://scoop.sh/):
 
-    # cinst pasteboard
+```
+# Make sure you have added scoop-extras bucket.
+$ scoop bucket add extras
+$ scoop install pasteboard
+```
+
+If you don't want to add scoop-extras bucket, you can install through a remote
+json file:
+
+```
+$ scoop install https://github.com/lukesampson/scoop-extras/blob/master/bucket/pasteboard.json
+```
 
 ## Usage
 
 To copy your SSH key to the clipboard:
 
-    # cd .ssh
-    # type id_rsa.pub | pbcopy
+```
+$ cd .ssh
+$ type id_rsa.pub | pbcopy
+```
+
 
 To write the contents of your clipboard to a file:
 
-    # cd C:\tmp
-    # pbpaste > output.txt
-    # pbpaste --lf > output.txt # Converting CRLF with LF
+```
+$ cd C:\tmp
+$ pbpaste > output.txt
+$ pbpaste --lf > output.txt # Converting CRLF to LF
+```
 
+## Changelogs
+
+### v1.2.0
+
+* Add `--lf` option to convert `CRLF` to `LF`
+* Support installation by scoop
 
 ## With thanks to
+* The original repository is [here](https://github.com/ghuntley/pasteboard).
 * The icon "<a href="https://thenounproject.com/term/clipboard/28312" target="_blank">Clipboard</a>" designed by <a href="https://thenounproject.com/Ilsur" target="_blank">Ilsur Aptukov</a> from The Noun Project.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To write the contents of your clipboard to a file:
 
     # cd C:\tmp
     # pbpaste > output.txt
+    # pbpaste --lf > output.txt # Converting CRLF with LF
 
 
 ## With thanks to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pasteboard
 
 [![Build Status](https://travis-ci.org/uzxmx/pasteboard.svg?branch=master)](https://travis-ci.org/uzxmx/pasteboard)
+
 ![Icon](https://i.imgur.com/rVJVL3U.png)
 
 Your favourite OSX command line clipboard manipulation libraries `pbcopy` and `pbpaste`ported over to Windows.

--- a/pbpaste/Program.cs
+++ b/pbpaste/Program.cs
@@ -13,8 +13,11 @@ namespace pbpaste
         static void Main(string[] args)
         {
             var pasteboard = Clipboard.GetText();
-
-            Console.WriteLine(pasteboard);
+            if (args.Length > 0 && "--lf".Equals(args[0]))
+            {
+                pasteboard = pasteboard.Replace("\r\n", "\n");
+            }
+            Console.Write(pasteboard);
         }
     }
 }


### PR DESCRIPTION
I use this package to copy/paste in Neovim on WSL. But when Neovim executes `pbpaste.exe`, there will be ^M shown in the editor due to the different line break "\r\n" v.s. "\n".

So this PR is going to add a new command line option `--lf`. When `--lf` is specified, the Windows line break "\r\n" will be replaced with Unix line break "\n".

Also, I changed `Console.WriteLine` to `Console.Write` to remove the trailing line break.